### PR TITLE
google-ads 23.1.0 ❄️

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,27 @@
 {% set name = "google-ads" %}
-{% set version = "25.0.0" %}
+{% set version = "23.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/google_ads-{{ version }}.tar.gz
-  sha256: 6b5f76cc93e833db60439d8b3e336a04ccb55611aefc31e8bf350ba1c723b1d0
+  url: https://github.com/googleads/google-ads-python/archive/refs/tags/23.1.0.tar.gz
+  sha256: 5ebf11c13f4761b5f73eb39187c2d41eee2d81334936c3a646be41b2112ad9c8
 
 build:
   number: 0
-  noarch: python
+  skip: True                            # [not (py>=38 and py<313)]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7,<3.12
+    - python
     - pip
     - setuptools
+    - wheel
   run:
-    - python >=3.7,<3.12
+    - python
     - google-auth-oauthlib >=0.3.0,<2.0.0
     - google-api-core >=2.13.0,<=3.0.0
     - googleapis-common-protos >=1.56.3,<2.0.0
@@ -28,8 +29,7 @@ requirements:
     - grpcio-status >=1.59.0,<2.0.0
     - proto-plus >=1.22.3,<2.0.0
     - pyyaml >=5.1,<7.0
-    - setuptools >=40.3.0
-    - protobuf >=4.25.0,<6.0.0
+    - protobuf >=4.25.0,<5.0.0
 
 test:
   imports:
@@ -37,8 +37,10 @@ test:
     - google.ads
   commands:
     - pip check
+    - python noxfile.py
   requires:
     - pip
+    - python
 
 about:
   home: https://github.com/googleads/google-ads-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,12 +6,14 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 15c7a5953f70c52054020bc70426b2963ebf5ab1486912d802de17d7af40989b
+  url: https://github.com/googleads/google-ads-python/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 5ebf11c13f4761b5f73eb39187c2d41eee2d81334936c3a646be41b2112ad9c8
+  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  #sha256: 15c7a5953f70c52054020bc70426b2963ebf5ab1486912d802de17d7af40989b
 
 build:
   number: 0
-  skip: True                            # [not (py>=38 and py<313)]
+  skip: True                            # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -36,9 +38,14 @@ test:
     - google
     - google.ads
   commands:
+    - rm tests/config_test.py tests/client_test.py
     - pip check
+    - python -m unittest discover --buffer -s tests -p "*_test.py"
   requires:
     - pip
+    - python
+  source_files:
+    - tests
 
 about:
   home: https://github.com/googleads/google-ads-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/googleads/google-ads-python/archive/refs/tags/23.1.0.tar.gz
-  sha256: 5ebf11c13f4761b5f73eb39187c2d41eee2d81334936c3a646be41b2112ad9c8
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 15c7a5953f70c52054020bc70426b2963ebf5ab1486912d802de17d7af40989b
 
 build:
   number: 0
@@ -37,16 +37,16 @@ test:
     - google.ads
   commands:
     - pip check
-    - python noxfile.py
   requires:
     - pip
-    - python
 
 about:
   home: https://github.com/googleads/google-ads-python
   summary: Client library for the Google Ads API
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
+  description: This project hosts the Python client library for the Google Ads API.
   dev_url: https://github.com/googleads/google-ads-python
   doc_url: https://developers.google.com/google-ads/api/docs/start
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,9 @@ package:
   version: {{ version }}
 
 source:
+  # Use GH for upstream tests
   url: https://github.com/googleads/google-ads-python/archive/refs/tags/{{ version }}.tar.gz
   sha256: 5ebf11c13f4761b5f73eb39187c2d41eee2d81334936c3a646be41b2112ad9c8
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  #sha256: 15c7a5953f70c52054020bc70426b2963ebf5ab1486912d802de17d7af40989b
 
 build:
   number: 0


### PR DESCRIPTION
google-ads 23.1.0 ❄️

**Destination channel:** Snowflake

### Links

- [PKG-4479](https://anaconda.atlassian.net/browse/PKG-4479) 
- [Upstream repository](https://github.com/googleads/google-ads-python/tree/23.1.0)

### Explanation of changes:

- Corrected google-ads version
- Corrected Python version required
- Corrected dependency versions
- Completed about section
- I initially attempted to include the upstream tests, but they involved packages that were absent from the available channels.


[PKG-4479]: https://anaconda.atlassian.net/browse/PKG-4479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ